### PR TITLE
should not find up the tree any more if file with another extension candidate exists

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1460,6 +1460,29 @@ describe('Properties: `findUp`', function() {
     expect(result).toEqual(expected);
     done();
   });
+
+  it('does not search up the tree any more if file with another extension candidate exists', function(done) {
+    var pathObj = {
+      findUp: true,
+      path: '.',
+      extensions: ['.js', '.json'],
+    };
+
+    var defaultObj = {
+      name: 'index',
+      cwd: path.resolve(cwd, 'test/fixtures/fined'),
+    };
+
+    var expected = {
+      path: path.resolve(cwd, 'test/fixtures/fined/index.json'),
+      extension: '.json',
+    };
+
+    var result = fined(pathObj, defaultObj);
+
+    expect(result).toEqual(expected);
+    done();
+  });
 });
 
 describe('Symbolic links', function() {


### PR DESCRIPTION
When directory tree is as follows:

```
foo/
  appfile.js
  bar/
    appfile.json
```

and `fined` is passed `pathObj` as follows:

``` js
fined({
  findUp: true,
  path: '.',
  name: 'appfile',
  extensions: ['.js', '.json'],
  cwd: 'foo/bar'
});
```

the current code returns path of `foo/appfile.js`.

This PR makes it correct that `fined` returns path of `foo/bar/appfile.json` in this case.
