### PR TITLE
Use built-in Array.isArray. [closes #4]

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var fs = require('fs');
 var path = require('path');
 
 var isString = require('lodash.isstring');
-var isArray = require('lodash.isarray');
 var isPlainObject = require('lodash.isplainobject');
 var isEmpty = require('lodash.isempty');
 var pick = require('lodash.pick');
@@ -132,7 +131,7 @@ function createExtensionArray(exts) {
     return [exts];
   }
 
-  if (isArray(exts)) {
+  if (Array.isArray(exts)) {
     exts = exts.filter(isString);
     return (exts.length > 0) ? exts : [''];
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "expand-tilde": "^1.2.1",
     "lodash.assignwith": "^4.0.7",
-    "lodash.isarray": "^4.0.0",
     "lodash.isempty": "^4.2.1",
     "lodash.isplainobject": "^4.0.4",
     "lodash.isstring": "^4.0.1",


### PR DESCRIPTION
This PR removes the `lodash.isarray` dep in favor of built-in `Array.isArray`.
The `lodash.isarray` dep just does `module.exports = Array.isArray`.
