### PR TITLE
New: Allow name & path properties to have an extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,12 @@ function expandPath(pathObj, defaultObj) {
     basedir = path.resolve(parsed.root);
   }
 
+  if (parsed.ext) {
+    filePath = filePath.slice(0, -parsed.ext.length);
+    // This ensures that only the original extension is matched.
+    extArr = [parsed.ext];
+  }
+
   return {
     path: filePath,
     basedir: basedir,

--- a/test/index.js
+++ b/test/index.js
@@ -149,6 +149,105 @@ describe('Basic behaviors', function() {
     expect(result).toEqual(expected);
     done();
   });
+
+  it('accepts paths with extensions already', function(done) {
+    var pathObj = {
+      path: 'test/fixtures/fined/app.js',
+      cwd: cwd,
+      extensions: ['.json', '.js'],
+    };
+
+    var expected = {
+      path: path.resolve(cwd, 'test/fixtures/fined', 'app.js'),
+      extension: '.js',
+    };
+
+    var result = fined(pathObj);
+
+    expect(result).toEqual(expected);
+    done();
+  });
+
+  it('only matches the extension specified in path', function(done) {
+    var pathObj = {
+      path: 'test/fixtures/fined/appfile.js',
+      cwd: cwd,
+      extensions: ['.json', '.js'],
+    };
+
+    var expected = {
+      path: path.resolve(cwd, 'test/fixtures/fined', 'appfile.js'),
+      extension: '.js',
+    };
+
+    var result = fined(pathObj);
+
+    expect(result).toEqual(expected);
+    done();
+  });
+
+  it('accepts name with extensions already', function(done) {
+    var pathObj = {
+      path: 'test/fixtures/fined',
+      extensions: ['.json', '.js'],
+    };
+
+    var defaultObj = {
+      name: 'app.js',
+      cwd: cwd,
+    };
+
+    var expected = {
+      path: path.resolve(cwd, 'test/fixtures/fined', 'app.js'),
+      extension: '.js',
+    };
+
+    var result = fined(pathObj, defaultObj);
+
+    expect(result).toEqual(expected);
+    done();
+  });
+
+  it('only matches the extension specified in name', function(done) {
+    var pathObj = {
+      path: 'test/fixtures/fined',
+      extensions: ['.json', '.js'],
+    };
+
+    var defaultObj = {
+      name: 'appfile.js',
+      cwd: cwd,
+    };
+
+    var expected = {
+      path: path.resolve(cwd, 'test/fixtures/fined', 'appfile.js'),
+      extension: '.js',
+    };
+
+    var result = fined(pathObj, defaultObj);
+
+    expect(result).toEqual(expected);
+    done();
+  });
+
+  it('only ignores the extension at the end of the path', function(done) {
+    var pathObj = {
+      path: 'test/fixtures/fined/.js/app.js',
+      cwd: cwd,
+      extensions: ['.json', '.js'],
+    };
+
+    var expected = {
+      path: path.resolve(cwd, 'test/fixtures/fined/.js', 'app.js'),
+      extension: '.js',
+    };
+
+    var result = fined(pathObj);
+
+    expect(result).toEqual(expected);
+    done();
+  });
+
 });
 
 describe('Argument defaulting', function() {


### PR DESCRIPTION
@sttk I've been hacking on the `extends` syntax idea and I found it weird that this module can't accept a `path` or `name` property that already has an extension.  These changes should allow that.